### PR TITLE
Filter real devices in `findmnt`.

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -163,7 +163,7 @@ _action_kernels() {
 
 _found_root() {
 	local _root
-	_root="$(findmnt -r -n -o SOURCE /)"
+	_root="$(findmnt --real -r -n -o SOURCE /)"
 	if [ "$?" != 0 ] || [ -z "$_root" ]; then
 		echo "Something went wrong while searching for root" >&2
 		return 3
@@ -174,7 +174,7 @@ _found_root() {
 
 _found_boot() {
 	local _boot
-	_boot="$(findmnt -r -n -o SOURCE "$BOOT_DIR")"
+	_boot="$(findmnt --real -r -n -o SOURCE "$BOOT_DIR")"
 	if [ "$?" != 0 ] || [ -z "$_boot" ]; then
 		echo "Something went wrong while searching for boot" >&2
 		return 3


### PR DESCRIPTION
This PR ticket replaces #5, as #5 used `master` branch on my forked repository. However due I might commit more changes in the future, I had to create a separate branch for this PR so it won't contain changes not being scope of this PR.

Original description of PR from #5: 

> Currently, `kesboot` will pick any file system available first at the list, including virtual ones, for `BOOT_DIR` and `ROOT_DEVICE`. This causes on some workflows to pick file system like `systemd-1` instead of path to real block device.
>
> This PR aims to fix that by using `--real` flag within `findmnt`.